### PR TITLE
Correct samtools sort output in flair.py align

### DIFF
--- a/flair.py
+++ b/flair.py
@@ -68,7 +68,7 @@ if mode == 'align':
 		sys.exit()
 
 	if args.v:  # samtools verison 1.9
-		subprocess.call([args.sam, 'sort', '-@', args.t, args.o+'.unsorted.bam', '-o', args.o])
+		subprocess.call([args.sam, 'sort', '-@', args.t, args.o+'.unsorted.bam', '-o', args.o+'.bam'])
 	elif subprocess.call([args.sam, 'sort', '-@', args.t, args.o+'unsorted.bam', args.o]):
 		sys.stderr.write('If using samtools v1.9, please specify -v1.9 argument\n')
 		sys.exit()


### PR DESCRIPTION
In the arguments for samtools sort (v1.9) the output (-o) was specified without bam extension (which is expected in the next call to samtools index)