### PR TITLE
find_alt3prime_5prime_ss.py problem with columns 18 and 20

### DIFF
--- a/bin/find_alt3prime_5prime_ss.py
+++ b/bin/find_alt3prime_5prime_ss.py
@@ -12,10 +12,9 @@ except:
 
 def get_junctions_psl(starts, sizes):
 	junctions = set()
-	if len(starts) != 1:
-		for b in range(len(starts)-1):
-			junctions.add((starts[b]+sizes[b], starts[b+1]))
-		return junctions
+	for b in range(len(starts)-1):
+		junctions.add((starts[b]+sizes[b], starts[b+1]))
+	return junctions
 
 def pslreader(psl, index=0, fiveprimeon=False):
 	junctiondict = {}
@@ -113,9 +112,3 @@ alljuncs = pslreader(open(sys.argv[1]), fiveprimeon=True)
 with open(outfilename5, 'wt') as outfile:
 	writer = csv.writer(outfile, delimiter='\t')
 	find_altss(alljuncs, writer, fiveprimeon=True)
-
-
-
-
-
-


### PR DESCRIPTION
Fixes #12 

It sounds like I was having similar issues to #12 . The script was running into problems with lists of length 1 in columns 18 or 20. I removed the if statement so it goes directly to the for loop. This seems to resolve the issue. 