### PR TITLE
Fixed temp directory error in flair.py

### DIFF
--- a/flair.py
+++ b/flair.py
@@ -268,7 +268,7 @@ elif mode == 'collapse':
 			else:
 				if not os.path.isdir(args.temp_dir):
 					subprocess.call(['mkdir', args.temp_dir])
-				alignout = args.temp_dir + '/' + tempfile_name[tempfile_name.rfind('/'):]+'/.firstpass'
+				alignout = args.temp_dir + '/' + tempfile_name[tempfile_name.rfind('/'):]+'.firstpass'
 			if args.salmon:
 				if subprocess.call([args.m, '-a', '-t', args.t, args.o+'.firstpass.fa', r], \
 					stdout=open(alignout+'.sam', "w")):
@@ -294,8 +294,8 @@ elif mode == 'collapse':
 					alignout+'.q1.counts'])
 				count_files += [alignout+'.q1.counts']
 				align_files = [alignout+'.sam', alignout+'.q1.sam']
-	except:
-		sys.stderr.write('Possible minimap2/samtools error, please check that all file, directory, and executable paths exist\n')
+	except Exception as e:
+		sys.stderr.write(str(e)+'\n\n\nPossible minimap2/samtools error, please check that all file, directory, and executable paths exist\n')
 		sys.exit(1)
 
 	subprocess.call([sys.executable, path+'bin/combine_counts.py'] + count_files + [args.o+'.firstpass.q1.counts'])


### PR DESCRIPTION
Original code gave the following problem when specifying my own temp directory:
```
Annotated ends extracted from GTF
Read data extracted
Single-exon genes grouped, collapsing
Filtering isoforms
Renaming isoforms
Aligning reads to first-pass isoform reference
Traceback (most recent call last):
  File "flair.py", line 289, in <module>
    args.o+'.firstpass.fa', r], stdout=open(alignout+'.sam', "w")):
FileNotFoundError: [Errno 2] No such file or directory: '.../tmp//tmpp20_kgoo/.firstpass.sam'
```

Line 271 creates a file path, but the `tempfile_name[]` bit is surrounded by a '/' on both sides, turning it into a never created sub directory of the tmp file specified. I assumed the / is too much but perhaps you prefer to create the directory first instead.

Also, the generic except on line 297 caught the error without telling the actual problem it ran into, hence I included the original error message itself instead for debugging.