### PR TITLE
correcting align_Files to align_files

### DIFF
--- a/flair.py
+++ b/flair.py
@@ -317,7 +317,7 @@ elif mode == 'collapse':
 			if args.quality != '0' and not args.trust_ends:
 				subprocess.call([args.sam, 'view', '-q', args.quality, '-h', '-S', alignout+'.sam'], \
 					stdout=open(alignout+'.q.sam', 'w'))
-				align_Files += [alignout+'.sam']
+				align_files += [alignout+'.sam']
 			else:
 				subprocess.call(['mv', alignout+'.sam', alignout+'.q.sam'])
 			count_cmd = [sys.executable, path+'bin/count_sam_transcripts.py', '-s', alignout+'.q.sam', \


### PR DESCRIPTION
A colleague noticed a NameError, confusingly not happening all the time but only for some datasets. He traced it to line 320. The variable there is not initialized as such, but does exist without a capital letter.