### PR TITLE
when -nvrna used caused  [ERROR] failed to open file '40' 

### DIFF
--- a/flair.py
+++ b/flair.py
@@ -45,7 +45,7 @@ def align():
 	try:
 		mm2_command = [args.m, '-ax', 'splice', '-t', args.t, '--secondary=no', args.g]+args.r
 		if args.n:
-			mm2_command[4:4] = ['-uf', '-k14']
+			mm2_command[5:5] = ['-uf', '-k14']
 		if args.quiet:
 			if subprocess.call(mm2_command, stdout=open(args.o+'.sam', 'w'), \
 			stderr=open(args.o+'.mm2_stderr', 'w')):


### PR DESCRIPTION
`[ERROR] failed to open file '40'`  The "file number" is was the -t arg given, this issue arose with `--nvrna ` arg, # #