### PR TITLE
Fixed bugs and enhanced isoform quantification

### DIFF
--- a/bin/count_sam_transcripts.py
+++ b/bin/count_sam_transcripts.py
@@ -110,9 +110,17 @@ def count_transcripts_for_reads(read_names):
 			continue
 
 		
-		# If a uniquely mapped alignment is found, the read will be considered as the only candidate.
-		if (args.stringent and ordered_transcripts[-1][1].mapq >= args.quality):
-			ordered_transcripts = ordered_transcripts[-1:]
+		# Reads passing that mapq will be considered as candidates. 
+		max_mapq = ordered_transcripts[-1][1].mapq
+		if (args.stringent and max_mapq >= args.quality and max_mapq > 0):
+			counter = 0
+			# Finding all reads with the maximum mapq
+			for i in ordered_transcripts:
+				if i[1].mapq >= max_mapq:
+					counter += 1
+
+			ordered_transcripts = ordered_transcripts[-counter:]
+
 
 		# read in cigar info for stringent/trust_ends modes into transcript_coverage dict
 		# {transcript: (sum_matches, unmapped_left, unmapped_right, softclip_left, softclip_right)}

--- a/bin/count_sam_transcripts.py
+++ b/bin/count_sam_transcripts.py
@@ -23,8 +23,6 @@ parser.add_argument('-t', '--threads', default=4, type=int, action='store', dest
 	help='number of threads to use')
 parser.add_argument('--quality', default=1, type=int, action='store', dest='quality', \
 	help='minimum quality threshold to consider if ends are to be trusted (1)')
-parser.add_argument('--unique_quality', default=20, type=int, action='store', dest='uni_quality', \
-	help='minimum quality threshold to consider if a read is uniquely mapped (20)')
 parser.add_argument('--trust_ends', default=False, action='store_true', dest='trust_ends', \
 	help='specify if reads are generated from a long read method with minimal fragmentation')
 parser.add_argument('--generate_map', default='', action='store', type=str, dest='generate_map', \
@@ -113,7 +111,7 @@ def count_transcripts_for_reads(read_names):
 
 		
 		# If a uniquely mapped alignment is found, the read will be considered as the only candidate.
-		if (args.stringent and ordered_transcripts[-1][1].mapq >= args.uni_quality):
+		if (args.stringent and ordered_transcripts[-1][1].mapq >= args.quality):
 			ordered_transcripts = ordered_transcripts[-1:]
 
 		# read in cigar info for stringent/trust_ends modes into transcript_coverage dict

--- a/bin/psl_to_sequence.py
+++ b/bin/psl_to_sequence.py
@@ -35,6 +35,9 @@ def get_sequence(entry, seq):
 	pulledseq = ''
 	for block in range(len(blockstarts)):
 		pulledseq += seq[blockstarts[block]:blockstarts[block]+blocksizes[block]]
+
+	pulledseq = pulledseq.upper()
+
 	if strand == '-':
 		pulledseq = revcomp(pulledseq)
 	return pulledseq

--- a/flair.py
+++ b/flair.py
@@ -510,7 +510,7 @@ def collapse(genomic_range='', corrected_reads=''):
 			return 1
 
 	collapse_cmd = [sys.executable, path+'bin/collapse_isoforms_precise.py', '-q', precollapse, \
-			'-m', str(args.max_ends), '-w', args.w, '-n', args.n, '-o', args.o+'firstpass.unfiltered'+ext]
+			'-m', str(args.max_ends), '-w', args.w, '-s', args.s, '-n', args.n, '-o', args.o+'firstpass.unfiltered'+ext]
 	if args.f and not args.no_end_adjustment:
 		collapse_cmd += ['-f', args.f]
 	if args.i:
@@ -551,7 +551,7 @@ def collapse(genomic_range='', corrected_reads=''):
 	alignout = args.temp_dir + tempfile_name +'firstpass.'
 	try:
 		args.mm2_args = args.mm2_args.split(',')
-		if subprocess.call([args.m, '-a', '-t', args.t, '-N', '4'] + args.mm2_args + [args.o+'firstpass.fa'] + args.r, \
+		if subprocess.call([args.m, '-a', '-t', args.t, '-N', '4'] + [args.o+'firstpass.fa'] + args.r, \
 			stdout=open(alignout+'sam', 'w'), stderr=open(alignout+'mm2_stderr', 'w')):
 			return 1
 	except Exception as e:
@@ -608,8 +608,8 @@ def collapse(genomic_range='', corrected_reads=''):
 			subprocess.call([sys.executable, path+'bin/psl_to_gtf.py', args.o+'isoforms'+ext], \
 				stdout=open(args.o+'isoforms.gtf', 'w'))
 
-	subprocess.call(['rm', '-rf', args.o+'firstpass.fa', alignout+'q.counts'])
 	if not args.keep_intermediate:
+		subprocess.call(['rm', '-rf', args.o+'firstpass.fa', alignout+'q.counts'])
 		subprocess.call(['rm', args.o+'firstpass.q.counts', args.o+'firstpass'+ext])
 		subprocess.call(['rm', '-rf'] + glob.glob(args.temp_dir+'*'+tempfile_name+'*') + align_files + intermediate)
 	return args.o+'isoforms.bed', args.o+'isoforms.fa'
@@ -636,6 +636,8 @@ def quantify(isoform_sequences=''):
 	parser.add_argument('--quality', type=int, action='store', dest='quality', default=1, \
 		help='''minimum MAPQ of read assignment to an isoform. If using salmon, all alignments are
 		used (1)''')
+	parser.add_argument('--unique_quality', default=20, type=int, action='store', dest='uni_quality', \
+	        help='minimum quality threshold to consider if a read is uniquely mapped (20)')
 	parser.add_argument('-o', '--output', type=str, action='store', dest='o', \
 		default='counts_matrix.tsv', help='Counts matrix output file name prefix (counts_matrix.tsv)')
 	parser.add_argument('--salmon', type=str, action='store', dest='salmon', \

--- a/flair.py
+++ b/flair.py
@@ -554,11 +554,17 @@ def collapse(genomic_range='', corrected_reads=''):
 	count_files, align_files = [], []
 
 	alignout = args.temp_dir + tempfile_name +'firstpass.'
+
 	try:
-		args.mm2_args = args.mm2_args.split(',')
-		if subprocess.call([args.m, '-a', '-t', args.t, '-N', '4'] + [args.o+'firstpass.fa'] + args.r, \
-			stdout=open(alignout+'sam', 'w'), stderr=open(alignout+'mm2_stderr', 'w')):
-			return 1
+		if args.mm2_args:
+			args.mm2_args = args.mm2_args.split(',')
+			if subprocess.call([args.m, '-a', '-t', args.t, '-N', '4'] + args.mm2_args + [args.o+'firstpass.fa'] + args.r, \
+				stdout=open(alignout+'sam', 'w'), stderr=open(alignout+'mm2_stderr', 'w')):
+				return 1
+		else:
+			if subprocess.call([args.m, '-a', '-t', args.t, '-N', '4  '] + [args.o+'firstpass.fa'] + args.r, \
+                                stdout=open(alignout+'sam', 'w'), stderr=open(alignout+'mm2_stderr', 'w')):
+                                return 1
 	except Exception as e:
 		sys.stderr.write(str(e)+'\n\n\nMinimap2 error, please check that all file, directory, and executable paths exist\n')
 		return 1


### PR DESCRIPTION
Thanks for creating this wonderful package. While I used the program, I found few problems and made some updates for fixing bugs as well as a potentially better isoform choosing logic when `stringent` option is on. 

Mirror things:
1.	Currently, Flair is unable to handle soft-masked reference genome and it is fixed.
See issue (https://github.com/BrooksLabUCSC/flair/issues/168).

2.	Retained all intermediate files for troubleshoot when keep_intermediate is on in `flair.py`, including args.o+'firstpass.fa', alignout+'q.counts'.

3.	Fixed mm2_args problem but not just removing the argument, see issue (https://github.com/BrooksLabUCSC/flair/issues/175). 


Major bugs:
1.	The argument of minimum supporting reads in the `collapse` function was not passed to `collapse_isoforms_precise.py`, so some TSSs with sufficient support were also filtered. Currently, `collapse_isoforms_precise.py` will only choose TSS supported by 25% of reads. This value is also not the same as the value in its help manual, which stated `minimum proportion(s<1) or number of supporting reads(s>=1) for an isoform (0.1)`.

2.	When splicing donor and acceptor are at the same site, object `ssData` in `ssPrep.py` only stored the one that appeared first. Although this rarely happens, it does appear in real-life annotation (e.g. TMEM141 in gencode) and filtered those promising isoforms. This was fixed by storing the information of exon ends into two objects, `ssData_1` and `ssData_2`.

3.	When `stringent` argument is on, it will only select reads that cover 25 bp of the first and last exon. However, in `count_sam_transcripts.py`, it seems that it forgot to consider the strand information when determining the `first blocksize` and `last_blocksize`. If a gene is negative-stranded, the exon on the right side is the first exon, while the exon on the left side is the first exon. However, the script treated all exons on the left as the first exons and exons on the right as the last exons regardless of their strand. Unsurprisingly, the stringent classifier function, `is_stringent` will not work properly. As a result, reads not covering 25 bp of the first and last exon also passed the classifier.

Enhancement

Personally found that the transcript quantification does not work very well in both flair own quantification and salmon. For salmon, it needs specific arguments when handling ONT sequencing reads see the issue in salmon github, https://github.com/COMBINE-lab/salmon/issues/602. For flair-own quantification, when the stringent argument is on, in `flair.py`, after `samtools` processed reads filtered reads based on mapping quality, `count_sam_transcripts.py` will no longer take mapping quality into consideration for finding the best alignment (Even one alignment is far better than the chosen one).

The culprit could be the metrics it used. When an alignment is closer to the transcript end and possesses more nucleotide matches, it will be considered as a better one. However, this metric may fail to choose the best one when a read has more matches but percentage identity (PID) in the aligned region is poor. If we consider the PID in the aligned region as well as mapping quality, it may help to have a better transcript assignment for reads.

Furthermore, it may be beneficial if we create two kinds of filters for mapping quality, one is a hard mapping quality filter, like what flair currently using, another one is a soft mapping quality filter. When the stringent argument is on, reads passing the soft mapping quality and the one with the best mapping mapq will be considered as candidates for stringent criteria classification. On the other hand, no reads passing the soft mapping quality, their mapping quality will be considered as equally good and other metrics will be used to determine the best transcript assignment, as previous mentioned, e.g. PID and the distance to the transcript end.

The abovementioned bugs and enhancements have been implemented in this pull request.
