### PR TITLE
Revert "Stranded alignment for dRNA in flair quantify"

### DIFF
--- a/src/flair/flair.py
+++ b/src/flair/flair.py
@@ -704,10 +704,8 @@ def quantify(isoform_sequences=''):
 		help='''isoform .bed file, must be specified if --stringent or check_splice is specified''')
 	parser.add_argument('--stringent', default=False, action='store_true', dest='stringent',
 		help='''Supporting reads must cover 80 percent of their isoform and extend at least 25 nt into the
-				first and last exons. If those exons are themselves shorter than 25 nt, the requirement becomes
-				'must start within 4 nt from the start" or "must end within 4 nt from the end" ''')
-	parser.add_argument('--nvrna', action='store_true', dest='n', default=False,
-		help='specify this flag to use native-RNA specific alignment parameters for minimap2')
+                first and last exons. If those exons are themselves shorter than 25 nt, the requirement becomes
+                'must start within 4 nt from the start" or "must end within 4 nt from the end" ''')
 	parser.add_argument('--check_splice', default=False, action='store_true', dest='check_splice',
 		help='''enforce coverage of 4 out of 6 bp around each splice site and no
 		insertions greater than 3 bp at the splice site''')
@@ -772,8 +770,6 @@ def quantify(isoform_sequences=''):
 	for num, sample in enumerate(samData, 0):
 		sys.stderr.write('Step 1/3. Aligning sample %s_%s, %s/%s \r' % (sample[0], sample[2], num+1, len(samData)))
 		mm2_command = ['minimap2', '-a', '-N', '4', '-t', str(args.t), args.i, sample[-2]]
-		if args.n:
-			mm2_command[4:4] = ['-uf', '-k14']
 
 		try:
 			if subprocess.call(mm2_command, stdout=open(sample[-1], 'w'),


### PR DESCRIPTION
Reverts BrooksLabUCSC/flair#246

--nvrna tag from flair align was implementing different minimap2 flags that I thought it was: "-uf" is strand specific for splicing edges, rather than the mapping. Carrying over that flag from flair align to flair quantify does not work as intended (b/c mapping to a genome is not the same as mapping to a ~transcriptome).

Going to add a --for_only (direct RNA) and --rev_only (direct cDNA) flag to falir quantify for my own usages. I'll make a pull request, but not sure if it's necessary for other folks.