### PR TITLE
refactor: BLAS env variable without effect has been removed

### DIFF
--- a/src/flair/flair_diffExp.py
+++ b/src/flair/flair_diffExp.py
@@ -26,7 +26,6 @@ import numpy as np
 
 from flair import FlairError, FlairInputDataError, set_unix_path
 
-os.environ['OPENBLAS_NUM_THREADS'] = '1'
 import numpy as np
 
 


### PR DESCRIPTION
The export statment in line 29 of `src/flair/flair_diffExp.py` which read `os.environ['OPENBLAS_NUM_THREADS'] = '1'` has no effect. This PR proposes to delete this line:

- This environment variable is only relevant if your NumPy installation is using the OpenBLAS backend for linear algebra operations. If NumPy is linked against a different BLAS implementation (e.g., MKL, ATLAS), this setting will do nothing.
- In this script, NumPy is used mainly for basic array manipulations, list conversions, and simple statistics. There are no matrix manipulations, where BLAS parallelizations would kick in.
- To use this setting to avoid over-parallelization when running on shared resources is not necessary for the above-mentioned reasons.
