### PR TITLE
Add Python 3.13 and 3.14 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * General
   * fixed problems with some diffsplice_fishers_exact, and other
     auxiliary console script installs
+  * Added support for Python 3.13 and 3.14.
 
 ## [v3.0.0] 2025-11-31
 * General

--- a/misc/flair_conda_env.yaml
+++ b/misc/flair_conda_env.yaml
@@ -4,7 +4,8 @@ channels:
   - bioconda
   - conda
 
-# not yet tested with 3.13
+# FLAIR supports Python 3.12 through 3.14. Keep the reference environment on
+# the oldest supported version.
 dependencies:
   - python =3.12
   - minimap2 =2.30

--- a/misc/flair_dev_conda_env.yaml
+++ b/misc/flair_dev_conda_env.yaml
@@ -4,7 +4,8 @@ channels:
   - bioconda
   - conda-forge
 
-# bedtools 2.31.1 doesn't work with Python 3.13
+# FLAIR supports Python 3.12 through 3.14. Keep the development environment on
+# the oldest supported version.
 dependencies:
   - python =3.12
   - minimap2 =2.30

--- a/poetry.lock
+++ b/poetry.lock
@@ -2043,5 +2043,5 @@ dev = ["bump-my-version", "flake8", "sphinx", "sphinx-rtd-theme"]
 
 [metadata]
 lock-version = "2.1"
-python-versions = ">=3.12,<3.13"
-content-hash = "2c0363d757c9426d61906182e4d4a23c018ededda1bb665c9c6946e213329538"
+python-versions = ">=3.12,<3.15"
+content-hash = "80fed548604cc44cdd5cd037067ff1a10f3cf3396bd583482c835443ef2f2d6f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
 ]
 license = {text = "BSD 3-clause"}
 readme = "README.md"
-requires-python = ">=3.12,<3.13"
+requires-python = ">=3.12,<3.15"
 
 dependencies = [
     "pysam (>=0.23.0,<0.24.0)",

--- a/src/flair/flair_collapse.py
+++ b/src/flair/flair_collapse.py
@@ -1,7 +1,6 @@
 #! /usr/bin/env python3
 
 import sys
-import argparse
 import os
 import tempfile
 import glob
@@ -22,12 +21,13 @@ from flair.bed_to_gtf import bed_to_gtf
 from flair.subset_unassigned_reads import subset_unassigned_reads
 from flair.filter_isoforms_by_proportion_of_gene_expr import filter_isoforms_by_proportion_of_gene_expr
 from flair import FlairInputDataError
+from flair.pycbio.sys import cli
 
 run_id = 'removeme'
 # TODO: do not redefine args variables, it breaks your head.
 
 def collapse(genomic_range='', corrected_reads=''):
-    parser = argparse.ArgumentParser(description='take bed file of corrected reads and generate confident collapsed isoform models')
+    parser = cli.ArgumentParser(description='take bed file of corrected reads and generate confident collapsed isoform models')
     required = parser.add_argument_group('required named arguments')
     if not corrected_reads:
         required.add_argument('-q', '--query', type=str, default='', required=True,

--- a/src/flair/flair_correct.py
+++ b/src/flair/flair_correct.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 
-import argparse
 import sys
 import multiprocessing as mp
 import os
@@ -10,11 +9,12 @@ import pipettor
 from flair.ssUtils import addOtherJuncs, gtfToSSBed
 from flair.ssPrep import ssPrep
 from flair import FlairInputDataError
+from flair.pycbio.sys import cli
 
 import logging
 
 def parseargs(aligned_reads=''):
-    parser = argparse.ArgumentParser(description='take bed file of long RNA-seq reads and filter out those with anomalous splice junctions' \
+    parser = cli.ArgumentParser(description='take bed file of long RNA-seq reads and filter out those with anomalous splice junctions' \
                                      ' correct remaining to nearest orthogonally supported splice site')
     required = parser.add_argument_group('required named arguments')
     atleastone = parser.add_argument_group('at least one of the following arguments is required')

--- a/src/flair/flair_diffExp.py
+++ b/src/flair/flair_diffExp.py
@@ -15,7 +15,6 @@
 import os
 import os.path as osp
 import sys
-import argparse
 import errno
 import csv
 from collections import Counter
@@ -23,6 +22,7 @@ from scipy.stats import ttest_ind
 from statistics import median, mean
 import pipettor
 import numpy as np
+from flair.pycbio.sys import cli
 
 from flair import FlairError, FlairInputDataError, set_unix_path
 
@@ -396,7 +396,7 @@ def calculate_sig(args):
 
 def diffExp(counts_matrix=''):
     set_unix_path()
-    parser = argparse.ArgumentParser()
+    parser = cli.ArgumentParser()
 #       parser.add_argument('diffExp')
     required = parser.add_argument_group('required named arguments')
     if not counts_matrix:

--- a/src/flair/flair_diffSplice.py
+++ b/src/flair/flair_diffSplice.py
@@ -1,12 +1,12 @@
 #! /usr/bin/env python3
 
 import sys
-import argparse
 import os
 import os.path as osp
 import pipettor
 import logging
 from flair import FlairError, set_unix_path, FlairInputDataError
+from flair.pycbio.sys import cli
 
 pkgdir = osp.dirname(osp.realpath(__file__))
 diffSplice_drimSeq = osp.join(pkgdir, "diffSplice_drimSeq.R")
@@ -16,7 +16,7 @@ diffSplice_drimSeq = osp.join(pkgdir, "diffSplice_drimSeq.R")
 
 def diffSplice(isoforms='', counts_matrix=''):
     set_unix_path()
-    parser = argparse.ArgumentParser()
+    parser = cli.ArgumentParser()
     required = parser.add_argument_group('required named arguments')
     if not isoforms:
         required.add_argument('-i', '--isoforms', action='store', required=True,

--- a/src/flair/flair_fusion.py
+++ b/src/flair/flair_fusion.py
@@ -1,7 +1,6 @@
 #! /usr/bin/env python3
 
 import sys
-import argparse
 import os, glob
 import pipettor
 import pysam
@@ -14,6 +13,7 @@ from flair import transcriptomic_chimeras
 from flair import genomic_chimeras
 from collections import defaultdict
 from flair import FlairInputDataError
+from flair.pycbio.sys import cli
 
 
 def def_value():
@@ -26,7 +26,7 @@ def report_nofusions(outputprefix):
         f.close()
 
 def detectfusions():
-    parser = argparse.ArgumentParser()
+    parser = cli.ArgumentParser()
     required = parser.add_argument_group('required named arguments')
     required.add_argument('-g', '--genome',
                           type=str, required=True, help='FastA of reference genome')

--- a/src/flair/flair_quantify.py
+++ b/src/flair/flair_quantify.py
@@ -3,7 +3,6 @@
 import os
 import sys
 import re
-import argparse
 import pipettor
 import os
 import numpy as np
@@ -12,11 +11,12 @@ import tempfile
 import time
 import logging
 import pipettor, pysam
+from flair.pycbio.sys import cli
 
 os.environ['OPENBLAS_NUM_THREADS'] = '1'
 
 def quantify(isoform_sequences=''):
-    parser = argparse.ArgumentParser(description='takes in many long-read RNA-seq reads files and quantifies them against a single transcriptome. A stringent, full-read-match-based approach')
+    parser = cli.ArgumentParser(description='takes in many long-read RNA-seq reads files and quantifies them against a single transcriptome. A stringent, full-read-match-based approach')
     required = parser.add_argument_group('required named arguments')
     required.add_argument('-r', '--reads_manifest', action='store', dest='r', type=str,
                     required=True, help='Tab delimited file containing sample id, condition, batch, reads.fq')

--- a/src/flair/flair_transcriptome.py
+++ b/src/flair/flair_transcriptome.py
@@ -1,7 +1,6 @@
 #! /usr/bin/env python3
 
 import sys
-import argparse
 import os
 import pipettor
 import glob
@@ -16,12 +15,13 @@ import multiprocessing as mp
 import time
 from collections import Counter
 from flair import FlairInputDataError
+from flair.pycbio.sys import cli
 
 
 # export PATH="/private/groups/brookslab/cafelton/git-flair/flair/bin:/private/groups/brookslab/cafelton/git-flair/flair/src/flair:$PATH"
 
 def get_args():
-    parser = argparse.ArgumentParser()
+    parser = cli.ArgumentParser()
     parser.add_argument('-b', '--genomealignedbam',
                         help='Sorted and indexed bam file aligned to the genome')
     parser.add_argument('-g', '--genome', type=str,

--- a/src/flair/flair_variants.py
+++ b/src/flair/flair_variants.py
@@ -1,7 +1,6 @@
 #! /usr/bin/env python3
 
 import sys
-import argparse
 import os, glob, math
 import pipettor, subprocess
 import pysam
@@ -9,6 +8,7 @@ os.environ['OPENBLAS_NUM_THREADS'] = '1'
 import numpy as np
 import shutil
 from flair import FlairInputDataError
+from flair.pycbio.sys import cli
 
 compbase = {'A':'T', 'T':'A', 'C':'G', 'G':'C', 'N':'N'}
 
@@ -102,7 +102,7 @@ def translate(seq):
     return protein
 
 def parse_args():
-    parser = argparse.ArgumentParser()
+    parser = cli.ArgumentParser()
     parser.add_argument('-m', '--manifest', required=True, type=str,
                         help="path to manifest files that points to sample names + bam files aligned to transcriptome. Each line of file should be tab separated.")
     parser.add_argument('-o', '--output_prefix', default='flair',

--- a/src/flair/plot_isoform_usage.py
+++ b/src/flair/plot_isoform_usage.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 import os
-import argparse
 os.environ['OPENBLAS_NUM_THREADS'] = '1'
 import numpy as np
 import matplotlib
@@ -10,13 +9,14 @@ import matplotlib.pyplot as plt
 import matplotlib.patches as mplpatches
 import matplotlib.colors as mcolors
 from flair import FlairInputDataError
+from flair.pycbio.sys import cli
 
 def parse_args():
     desc = '''The script will produce two images, one of the isoform models and another of the usage proportions.
     The most highly expressed isoforms across all the samples will be plotted.
     The minor isoforms are aggregated into a gray bar. You can toggle min_reads or
     color_palette to plot more isoforms.'''
-    parser = argparse.ArgumentParser(description=desc)
+    parser = cli.ArgumentParser(description=desc)
     parser.add_argument('isoforms', type=str, action='store',
                         help='isoforms in bed format')
     parser.add_argument('counts_matrix', type=str, action='store',

--- a/src/flair/predictProductivity.py
+++ b/src/flair/predictProductivity.py
@@ -21,6 +21,7 @@ import sys
 import pipettor
 import os
 from flair import FlairInputDataError
+from flair.pycbio.sys import cli
 ########################################################################
 # CommandLine
 ########################################################################
@@ -45,8 +46,7 @@ class CommandLine(object):
         CommandLine constructor.
         Implements a parser to interpret the command line argv string using argparse.
         '''
-        import argparse
-        self.parser = argparse.ArgumentParser(description=' predictProductivity - a tool.')
+        self.parser = cli.ArgumentParser(description=' predictProductivity - a tool.')
         # Add args
         self.parser.add_argument('-i', "--input_isoforms", action='store', required=True, help='Input collapsed isoforms in bed12 format.')
         self.parser.add_argument('-g', "--gtf", action='store', required=True, help='Gencode annotation file.')

--- a/src/flair/pycbio/sys/cli.py
+++ b/src/flair/pycbio/sys/cli.py
@@ -2,11 +2,44 @@
 """Support for command line parsing"""
 import argparse
 import logging
+import re
 import traceback
 from io import StringIO
 from flair.pycbio import NoStackError
 from flair.pycbio.sys.objDict import ObjDict
 from flair.pycbio.sys import loggingOps
+
+
+class HelpFormatter(argparse.HelpFormatter):
+    """Keep option metavars stable across supported Python versions."""
+
+    def _get_actions_usage_parts(self, actions, groups):
+        parts = super()._get_actions_usage_parts(actions, groups)
+        usage = ' '.join(parts)
+        return re.findall(r'\(.*?\)+(?=\s|$)|\[.*?\]+(?=\s|$)|\S+', usage)
+
+    def _format_action_invocation(self, action):
+        if not action.option_strings:
+            default = self._get_default_metavar_for_positional(action)
+            metavar, = self._metavar_formatter(action, default)(1)
+            return metavar
+
+        if action.nargs == 0:
+            return ', '.join(action.option_strings)
+
+        default = self._get_default_metavar_for_optional(action)
+        args_string = self._format_args(action, default)
+        return ', '.join(f'{option_string} {args_string}'
+                         for option_string in action.option_strings)
+
+
+class ArgumentParser(argparse.ArgumentParser):
+    """Argument parser with help output stable across Python versions."""
+
+    def __init__(self, *args, **kwargs):
+        kwargs.setdefault('formatter_class', HelpFormatter)
+        super().__init__(*args, **kwargs)
+
 
 def splitOptionsArgs(parser, inargs):
     """Split command line arguments into two objects one of option arguments
@@ -24,7 +57,7 @@ def splitOptionsArgs(parser, inargs):
             args[name] = value
     return opts, args
 
-class ArgumentParserExtras(argparse.ArgumentParser):
+class ArgumentParserExtras(ArgumentParser):
     """Wrapper around ArgumentParser that adds logging
     related options.  Also can parse splitting options and positional
     arguments into separate objects.


### PR DESCRIPTION
Created with the assistance of Codex, GPT-5.6. Manually reviewed and tested.
Close #669.

## Summary

This PR adds official FLAIR support for Python 3.13 and Python 3.14 while retaining Python 3.12 compatibility.

The existing package metadata limited installation to Python 3.12:

requires-python = ">=3.12,<3.13"

Testing showed that FLAIR’s runtime and compiled Python dependencies work on both newer versions. The only incompatibility found was a change in Python 3.13’s standard-library argparse help formatting, which caused golden help-output tests to fail despite functional outputs remaining identical.

Closes #ISSUE_NUMBER

## Changes

### Expand supported Python versions

Changed the supported range in pyproject.toml to:
```
requires-python = ">=3.12,<3.15"
```
The generated wheel now includes classifiers for Python 3.12, 3.13, and 3.14.

The corresponding Python range and content hash in poetry.lock were regenerated with Poetry 2.2.1.

### Preserve CLI help output across Python versions

Python 3.13 changed how argparse renders options with values:
```
# Python 3.12
-o OUTPUT, --output OUTPUT

# Python 3.13+
-o, --output OUTPUT
```
It also changed how mutually exclusive argument groups wrap in usage messages. These differences caused the help-output regression tests to fail on Python 3.13 and 3.14.

This PR adds shared HelpFormatter and ArgumentParser classes in flair.pycbio.sys.cli. They preserve FLAIR’s existing Python 3.12 help format across all supported versions.

The shared parser is now used by the tested public commands:

- flair align
- flair correct
- flair collapse
- flair quantify
- flair diffexp
- flair diffsplice
- flair transcriptome
- flair fusion
- flair variants
- predictProductivity
- plot_isoform_usage
- diff_iso_usage

This avoids maintaining separate golden help files for each Python version and prevents an unnecessary user-visible CLI documentation change.

### Update environment documentation

Updated both Conda environment files to state that FLAIR supports Python 3.12 through 3.14.

The reference and development environments remain pinned to Python 3.12 because it is the oldest supported version. This continues to exercise the lower compatibility boundary while allowing users to install the Python package with 3.13 or 3.14.

### Update changelog

Added Python 3.13 and 3.14 support to the upcoming release notes.

## Test environment

Tests were run from commit c17913a on Linux x86_64 using:

| Component | Python 3.13 environment | Python 3.14 environment |
|---|---:|---:|
| Python | 3.13.5 | 3.14.2 |
| Compiler | GCC 14.3.0 | GCC 15.2.0 |
| mappy | 2.31 | 2.31 |
| pysam | 0.23.3 | 0.23.3 |
| ncls | 0.0.70 | 0.0.70 |
| NumPy | 2.5.2 | 2.5.2 |
| SciPy | 1.18.0 | 1.18.0 |
| Matplotlib | 3.11.1 | 3.11.1 |

External tools used by the integration suite:

- minimap2 2.30
- SAMtools 1.22.1
- BEDTools 2.31.1
- Bioconductor 3.23
- R 4.6.1

## Test results

### Package build and installation

The wheel built successfully and installed without overriding Requires-Python on:

- Python 3.12.3
- Python 3.13.5
- Python 3.14.2

The wheel metadata reports:
```
Requires-Python: >=3.12,<3.15
Classifier: Programming Language :: Python :: 3.12
Classifier: Programming Language :: Python :: 3.13
Classifier: Programming Language :: Python :: 3.14
```
### Base integration suite

The following passed on both Python 3.13 and Python 3.14:

make test-base-installed

This covers:

- alignment
- correction
- transcript collapsing
- quantification
- transcriptome construction
- transcriptome combination
- fusion detection
- productivity prediction
- differential isoform usage
- isoform-usage plotting
- partitioning
- CLI help output

All generated functional outputs matched the existing expected results.

### R-backed tests

The following also passed on Python 3.13 and Python 3.14:
```
make -C test test-with-R use_installed_flair=yes
```
This covers the diffexp and diffsplice workflows using Bioconductor 3.23 and R 4.6.1.

### Python 3.12 regression coverage

The built wheel installed successfully on Python 3.12.3, and the complete CLI help-output suite passed unchanged. This confirms that the compatibility formatter does not change the existing Python 3.12 interface.

### Packaging and lint checks

The following passed:
```
poetry check --lock
poetry build
make lint pycbio-lint
git diff --check
```
## Test limitation

The Longshot-dependent functional variant-calling test was skipped because Longshot was not available in the test environment. This is the suite’s existing conditional behavior.

The `flair variants --help` regression test passed on both Python versions, and the core Python dependencies used by the variants module imported successfully.
