### PR TITLE
Fix loss of fusion exon blocks starting at synthetic locus boundaries

### DIFF
--- a/src/flair/convert_synthetic_to_genome_bed.py
+++ b/src/flair/convert_synthetic_to_genome_bed.py
@@ -109,7 +109,7 @@ def separate_exons_by_locus(esizes, estarts, numloci, locusbounds, start):
         thisstart, thisend = start + estarts[i], start + estarts[i] + esizes[i]
 
         for order in range(numloci):
-            if locusbounds[order][0] < thisstart and thisend <= locusbounds[order][1]:
+            if locusbounds[order][0] <= thisstart and thisend <= locusbounds[order][1]:
                 if starts[order] == None:
                     starts[order] = estarts[i]  # thisstart #- locusbounds[order][0]
                 exonindexes[order].append(i)
@@ -217,6 +217,10 @@ def convert_synthetic_isos(annotgtf, isoformsbed, readmapfile, readsfile, breakp
 
                 numloci = len(synthinfo)
                 starts, exonindexes = separate_exons_by_locus(esizes, estarts, numloci, locusbounds, start)
+                assigned_exons = sorted(i for indexes in exonindexes for i in indexes)
+                if assigned_exons != list(range(len(esizes))):
+                    print('Skipping ' + iso + ': not all synthetic exons could be assigned to exactly one locus', file=sys.stderr)
+                    continue
 
                 if None not in starts:
                     genomicbounds, outlines = convert_to_genomic_coords(numloci, synthinfo, exonindexes, starts, locusbounds, esizes, estarts, start, iso)
@@ -226,6 +230,4 @@ def convert_synthetic_isos(annotgtf, isoformsbed, readmapfile, readsfile, breakp
                         freadsfinal.update(isoreadsup[iso])
     out.close()
     write_final_fusion_reads(readsfile, freadsfinal)
-
-
 


### PR DESCRIPTION
## Issues

Fusion isoform exon blocks that start exactly at a synthetic locus lower boundary are currently dropped by `separate_exons_by_locus()` because the containment test uses a strict lower-bound comparison `locus_start < exon_start`:

https://github.com/BrooksLabUCSC/flair/blob/ab890c3676f3613f5acfd00a00f99a0d9d58f23c/src/flair/convert_synthetic_to_genome_bed.py#L112

But BED intervals include their start coordinate, so the comparison should be `locus_start <= exon_start`:

In an observed fusion isoform in our sequencing data, the first 1,466-bp block started at synthetic coordinate 0. That block was omitted during projection to genomic coordinates, producing an 1,753-bp genomic BED for a 3,219-bp isoform FASTA.

The conversion still passed because the existing check only verifies that every fusion locus received at least one exon; it does not verify that every input exon was assigned.

## Changes

  - Include the synthetic locus lower boundary when assigning exon blocks.
  - Verify that every input exon block is assigned exactly once before converting genomic coordinates.

## Validation

  After the modification, The affected isoform now retains all 12 blocks, and the projected BED block length remains 3,219 bp, matching the FASTA sequence.

